### PR TITLE
Improve typings and suppress warnings

### DIFF
--- a/src/Meta.php
+++ b/src/Meta.php
@@ -4,60 +4,60 @@ namespace Indielab\AutoScout24;
 
 class Meta
 {
-    private $_data = null;
-    
-    public function __construct(array $data)
-    {
-        $this->_data = $data;
-    }
-    
-    /**
-     * @return string i.e. `logo`
-     */
-    public function getParameterName()
-    {
-        return $this->_data['ParameterName'];
-    }
-    
-    /**
-     * @return string i.e `Qualilogo`
-     */
-    public function getDescription()
-    {
-        return $this->_data['Description'];
-    }
-    
-    /**
-     * @return string i.e. `Integer`
-     */
-    public function getValueType()
-    {
-        return $this->_data['ValueType'];
-    }
-    
-    /**
-     * @return boolean i.e. `false`
-     */
-    public function getAcceptsCustomValues()
-    {
-        return $this->_data['AcceptsCustomValues'];
-    }
-    
-    public function getCustomValuesBounds()
-    {
-        return $this->_data['CustomValuesBounds'];
-    }
-    
-    public function getFilterParameterNames()
-    {
-        return $this->_data['FilterParameterNames'];
-    }
-    
-    /**
-     * @return array Optinal Data
-     */
-    public function getOptions()
-    {
-        return $this->_data['Options'];
-    }
+	private $_data = null;
+
+	public function __construct(array $data)
+	{
+		$this->_data = $data;
+	}
+
+	/**
+	 * @return string i.e. `logo`
+	 */
+	public function getParameterName(): string
+	{
+		return $this->_data['ParameterName'];
+	}
+
+	/**
+	 * @return string i.e `Qualilogo`
+	 */
+	public function getDescription(): string
+	{
+		return $this->_data['Description'];
+	}
+
+	/**
+	 * @return string i.e. `Integer`
+	 */
+	public function getValueType(): string
+	{
+		return $this->_data['ValueType'];
+	}
+
+	/**
+	 * @return boolean i.e. `false`
+	 */
+	public function getAcceptsCustomValues(): bool
+	{
+		return $this->_data['AcceptsCustomValues'] ?? false;
+	}
+
+	public function getCustomValuesBounds()
+	{
+		return $this->_data['CustomValuesBounds'];
+	}
+
+	public function getFilterParameterNames()
+	{
+		return $this->_data['FilterParameterNames'];
+	}
+
+	/**
+	 * @return array Optinal Data
+	 */
+	public function getOptions(): array
+	{
+		return $this->_data['Options'] ?? [];
+	}
 }

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -4,60 +4,60 @@ namespace Indielab\AutoScout24;
 
 class Meta
 {
-	private $_data = null;
+    private $_data = null;
 
-	public function __construct(array $data)
-	{
-		$this->_data = $data;
-	}
+    public function __construct(array $data)
+    {
+        $this->_data = $data;
+    }
 
-	/**
-	 * @return string i.e. `logo`
-	 */
-	public function getParameterName(): string
-	{
-		return $this->_data['ParameterName'];
-	}
+    /**
+     * @return string i.e. `logo`
+     */
+    public function getParameterName(): string
+    {
+        return $this->_data['ParameterName'];
+    }
 
-	/**
-	 * @return string i.e `Qualilogo`
-	 */
-	public function getDescription(): string
-	{
-		return $this->_data['Description'];
-	}
+    /**
+     * @return string i.e `Qualilogo`
+     */
+    public function getDescription(): string
+    {
+        return $this->_data['Description'];
+    }
 
-	/**
-	 * @return string i.e. `Integer`
-	 */
-	public function getValueType(): string
-	{
-		return $this->_data['ValueType'];
-	}
+    /**
+     * @return string i.e. `Integer`
+     */
+    public function getValueType(): string
+    {
+        return $this->_data['ValueType'];
+    }
 
-	/**
-	 * @return boolean i.e. `false`
-	 */
-	public function getAcceptsCustomValues(): bool
-	{
-		return $this->_data['AcceptsCustomValues'] ?? false;
-	}
+    /**
+     * @return boolean i.e. `false`
+     */
+    public function getAcceptsCustomValues(): bool
+    {
+        return $this->_data['AcceptsCustomValues'] ?? false;
+    }
 
-	public function getCustomValuesBounds()
-	{
-		return $this->_data['CustomValuesBounds'];
-	}
+    public function getCustomValuesBounds()
+    {
+        return $this->_data['CustomValuesBounds'];
+    }
 
-	public function getFilterParameterNames()
-	{
-		return $this->_data['FilterParameterNames'];
-	}
+    public function getFilterParameterNames()
+    {
+        return $this->_data['FilterParameterNames'];
+    }
 
-	/**
-	 * @return array Optinal Data
-	 */
-	public function getOptions(): array
-	{
-		return $this->_data['Options'] ?? [];
-	}
+    /**
+     * @return array Optinal Data
+     */
+    public function getOptions(): array
+    {
+        return $this->_data['Options'] ?? [];
+    }
 }

--- a/src/MetaQueryIterator.php
+++ b/src/MetaQueryIterator.php
@@ -61,62 +61,63 @@ namespace Indielab\AutoScout24;
  */
 class MetaQueryIterator implements \Iterator
 {
-    private $_data = null;
-    
-    public function __construct(array $data)
-    {
-        $this->_data = $data;
-    }
-    
-    public function rewind()
-    {
-        return reset($this->_data);
-    }
-    
-    /**
-     * @return \Indielab\AutoScout24\Vehicle Returns the Vehicle Object.
-     */
-    public function current()
-    {
-        return new Meta(current($this->_data));
-    }
-    
-    public function key()
-    {
-        return key($this->_data);
-    }
-    
-    public function next()
-    {
-        return next($this->_data);
-    }
-    
-    public function valid()
-    {
-        return key($this->_data) !== null;
-    }
-    
-    /**
-     * Filters the query iterator by one item and returns the Object.
-     *
-     * @param string $varName
-     * @return \Indielab\AutoScout24\Meta
-     */
-    public function filter($varName)
-    {
-        $key = array_search($varName, array_column($this->_data, 'ParameterName'));
-        
-        return new Meta($this->_data[$key]);
-    }
-    
-    /**
-     *
-     * @param unknown $name
-     * @param unknown $args
-     * @return \Indielab\AutoScout24\Meta
-     */
-    public function __call($name, $args)
-    {
-        return $this->filter($name);
-    }
+	private $_data = null;
+
+	public function __construct(array $data)
+	{
+		$this->_data = $data;
+	}
+
+	public function rewind(): void
+	{
+		reset($this->_data);
+	}
+
+	/**
+	 * @return Meta Returns the Vehicle Object.
+	 */
+	public function current(): Meta
+	{
+		return new Meta(current($this->_data));
+	}
+
+	public function key(): int|string
+	{
+		return key($this->_data);
+	}
+
+	public function next(): void
+	{
+		next($this->_data);
+	}
+
+	public function valid(): bool
+	{
+		return key($this->_data) !== null;
+	}
+
+	/**
+	 * Filters the query iterator by one item and returns the Object.
+	 *
+	 * @param string $varName
+	 * @return \Indielab\AutoScout24\Meta
+	 */
+	public function filter(string $varName): Meta
+	{
+		$key = array_search($varName, array_column($this->_data, 'ParameterName'));
+
+		return new Meta($this->_data[$key]);
+	}
+
+	/**
+	 * Magic method to handle dynamic method calls.
+	 *
+	 * @param string $name The name of the method being called.
+	 * @param array $args The arguments passed to the method.
+	 * @return Meta The result of the dynamic method call processing.
+	 */
+	public function __call(string $name, array $args): Meta
+	{
+		return $this->filter($name);
+	}
 }

--- a/src/MetaQueryIterator.php
+++ b/src/MetaQueryIterator.php
@@ -5,63 +5,63 @@ namespace Indielab\AutoScout24;
 /**
  * Meta Query Iterator.
  *
- * @method \Indielab\AutoScout24\Meta lng()
- * @method \Indielab\AutoScout24\Meta page();
- * @method \Indielab\AutoScout24\Meta itemsPerPage()
- * @method \Indielab\AutoScout24\Meta vehtyp()
- * @method \Indielab\AutoScout24\Meta sort()
- * @method \Indielab\AutoScout24\Meta makefull()
- * @method \Indielab\AutoScout24\Meta modelfull()
- * @method \Indielab\AutoScout24\Meta make()
- * @method \Indielab\AutoScout24\Meta model()
- * @method \Indielab\AutoScout24\Meta typename()
- * @method \Indielab\AutoScout24\Meta body()
- * @method \Indielab\AutoScout24\Meta fuel()
- * @method \Indielab\AutoScout24\Meta trans()
- * @method \Indielab\AutoScout24\Meta drive()
- * @method \Indielab\AutoScout24\Meta polnorm()
- * @method \Indielab\AutoScout24\Meta liccat()
- * @method \Indielab\AutoScout24\Meta consrat()
- * @method \Indielab\AutoScout24\Meta cond()
- * @method \Indielab\AutoScout24\Meta bodycol()
- * @method \Indielab\AutoScout24\Meta intcol()
- * @method \Indielab\AutoScout24\Meta tshaft()
- * @method \Indielab\AutoScout24\Meta seg()
- * @method \Indielab\AutoScout24\Meta equip()
- * @method \Indielab\AutoScout24\Meta equipor()
- * @method \Indielab\AutoScout24\Meta prop()
- * @method \Indielab\AutoScout24\Meta extras()
- * @method \Indielab\AutoScout24\Meta yearfrom()
- * @method \Indielab\AutoScout24\Meta yearto()
- * @method \Indielab\AutoScout24\Meta kmfrom()
- * @method \Indielab\AutoScout24\Meta kmto()
- * @method \Indielab\AutoScout24\Meta seatsfrom()
- * @method \Indielab\AutoScout24\Meta seatsto()
- * @method \Indielab\AutoScout24\Meta doorsfrom()
- * @method \Indielab\AutoScout24\Meta doorsto()
- * @method \Indielab\AutoScout24\Meta pricefrom()
- * @method \Indielab\AutoScout24\Meta priceto()
- * @method \Indielab\AutoScout24\Meta ccmfrom()
- * @method \Indielab\AutoScout24\Meta ccmto()
- * @method \Indielab\AutoScout24\Meta co2emitfrom()
- * @method \Indielab\AutoScout24\Meta co2mitto()
- * @method \Indielab\AutoScout24\Meta consfrom()
- * @method \Indielab\AutoScout24\Meta consto()
- * @method \Indielab\AutoScout24\Meta hpfrom()
- * @method \Indielab\AutoScout24\Meta hpto()
- * @method \Indielab\AutoScout24\Meta rad()
- * @method \Indielab\AutoScout24\Meta loc()
- * @method \Indielab\AutoScout24\Meta age()
- * @method \Indielab\AutoScout24\Meta onlytoorder()
- * @method \Indielab\AutoScout24\Meta includetoorder()
- * @method \Indielab\AutoScout24\Meta hasimage()
- * @method \Indielab\AutoScout24\Meta logo()
+ * @method Meta lng()
+ * @method Meta page();
+ * @method Meta itemsPerPage()
+ * @method Meta vehtyp()
+ * @method Meta sort()
+ * @method Meta makefull()
+ * @method Meta modelfull()
+ * @method Meta make()
+ * @method Meta model()
+ * @method Meta typename()
+ * @method Meta body()
+ * @method Meta fuel()
+ * @method Meta trans()
+ * @method Meta drive()
+ * @method Meta polnorm()
+ * @method Meta liccat()
+ * @method Meta consrat()
+ * @method Meta cond()
+ * @method Meta bodycol()
+ * @method Meta intcol()
+ * @method Meta tshaft()
+ * @method Meta seg()
+ * @method Meta equip()
+ * @method Meta equipor()
+ * @method Meta prop()
+ * @method Meta extras()
+ * @method Meta yearfrom()
+ * @method Meta yearto()
+ * @method Meta kmfrom()
+ * @method Meta kmto()
+ * @method Meta seatsfrom()
+ * @method Meta seatsto()
+ * @method Meta doorsfrom()
+ * @method Meta doorsto()
+ * @method Meta pricefrom()
+ * @method Meta priceto()
+ * @method Meta ccmfrom()
+ * @method Meta ccmto()
+ * @method Meta co2emitfrom()
+ * @method Meta co2mitto()
+ * @method Meta consfrom()
+ * @method Meta consto()
+ * @method Meta hpfrom()
+ * @method Meta hpto()
+ * @method Meta rad()
+ * @method Meta loc()
+ * @method Meta age()
+ * @method Meta onlytoorder()
+ * @method Meta includetoorder()
+ * @method Meta hasimage()
+ * @method Meta logo()
  *
  * @author Basil Suter <basil@nadar.io>
  */
 class MetaQueryIterator implements \Iterator
 {
-	private $_data = null;
+	private array $_data;
 
 	public function __construct(array $data)
 	{
@@ -81,7 +81,7 @@ class MetaQueryIterator implements \Iterator
 		return new Meta(current($this->_data));
 	}
 
-	public function key(): int|string
+	public function key()
 	{
 		return key($this->_data);
 	}
@@ -100,7 +100,7 @@ class MetaQueryIterator implements \Iterator
 	 * Filters the query iterator by one item and returns the Object.
 	 *
 	 * @param string $varName
-	 * @return \Indielab\AutoScout24\Meta
+	 * @return Meta
 	 */
 	public function filter(string $varName): Meta
 	{

--- a/src/MetaQueryIterator.php
+++ b/src/MetaQueryIterator.php
@@ -61,63 +61,63 @@ namespace Indielab\AutoScout24;
  */
 class MetaQueryIterator implements \Iterator
 {
-	private array $_data;
+    private array $_data;
 
-	public function __construct(array $data)
-	{
-		$this->_data = $data;
-	}
+    public function __construct(array $data)
+    {
+        $this->_data = $data;
+    }
 
-	public function rewind(): void
-	{
-		reset($this->_data);
-	}
+    public function rewind(): void
+    {
+        reset($this->_data);
+    }
 
-	/**
-	 * @return Meta Returns the Vehicle Object.
-	 */
-	public function current(): Meta
-	{
-		return new Meta(current($this->_data));
-	}
+    /**
+     * @return Meta Returns the Vehicle Object.
+     */
+    public function current(): Meta
+    {
+        return new Meta(current($this->_data));
+    }
 
-	public function key()
-	{
-		return key($this->_data);
-	}
+    public function key()
+    {
+        return key($this->_data);
+    }
 
-	public function next(): void
-	{
-		next($this->_data);
-	}
+    public function next(): void
+    {
+        next($this->_data);
+    }
 
-	public function valid(): bool
-	{
-		return key($this->_data) !== null;
-	}
+    public function valid(): bool
+    {
+        return key($this->_data) !== null;
+    }
 
-	/**
-	 * Filters the query iterator by one item and returns the Object.
-	 *
-	 * @param string $varName
-	 * @return Meta
-	 */
-	public function filter(string $varName): Meta
-	{
-		$key = array_search($varName, array_column($this->_data, 'ParameterName'));
+    /**
+     * Filters the query iterator by one item and returns the Object.
+     *
+     * @param string $varName
+     * @return Meta
+     */
+    public function filter(string $varName): Meta
+    {
+        $key = array_search($varName, array_column($this->_data, 'ParameterName'));
 
-		return new Meta($this->_data[$key]);
-	}
+        return new Meta($this->_data[$key]);
+    }
 
-	/**
-	 * Magic method to handle dynamic method calls.
-	 *
-	 * @param string $name The name of the method being called.
-	 * @param array $args The arguments passed to the method.
-	 * @return Meta The result of the dynamic method call processing.
-	 */
-	public function __call(string $name, array $args): Meta
-	{
-		return $this->filter($name);
-	}
+    /**
+     * Magic method to handle dynamic method calls.
+     *
+     * @param string $name The name of the method being called.
+     * @param array $args The arguments passed to the method.
+     * @return Meta The result of the dynamic method call processing.
+     */
+    public function __call(string $name, array $args): Meta
+    {
+        return $this->filter($name);
+    }
 }

--- a/src/VehicleQueryIterator.php
+++ b/src/VehicleQueryIterator.php
@@ -7,22 +7,22 @@ use Countable;
 class VehicleQueryIterator implements \Iterator, Countable
 {
     private array $_data;
-    
+
     public function __construct(array $data)
     {
         $this->_data = $data;
     }
-    
+
     public int $totalResultCount;
-    
+
     public int $totalPages;
-    
+
     public int $currentPage;
-    
+
     public int $currentPageResultCount;
-    
+
     public function count(): int
-	{
+    {
         return count($this->_data);
     }
 
@@ -30,27 +30,27 @@ class VehicleQueryIterator implements \Iterator, Countable
     {
         reset($this->_data);
     }
-    
+
     /**
      * @return Vehicle Returns the Vehicle Object.
      */
     public function current(): Vehicle
-	{
+    {
         return new Vehicle(current($this->_data));
     }
-    
+
     public function key()
     {
         return key($this->_data);
     }
-    
+
     public function next(): void
     {
         next($this->_data);
     }
-    
+
     public function valid(): bool
-	{
+    {
         return key($this->_data) !== null;
     }
 }

--- a/src/VehicleQueryIterator.php
+++ b/src/VehicleQueryIterator.php
@@ -6,36 +6,36 @@ use Countable;
 
 class VehicleQueryIterator implements \Iterator, Countable
 {
-    private $_data = null;
+    private array $_data;
     
     public function __construct(array $data)
     {
         $this->_data = $data;
     }
     
-    public $totalResultCount;
+    public int $totalResultCount;
     
-    public $totalPages;
+    public int $totalPages;
     
-    public $currentPage;
+    public int $currentPage;
     
-    public $currentPageResultCount;
+    public int $currentPageResultCount;
     
-    public function count()
-    {
+    public function count(): int
+	{
         return count($this->_data);
     }
 
-    public function rewind()
+    public function rewind(): void
     {
-        return reset($this->_data);
+        reset($this->_data);
     }
     
     /**
-     * @return \Indielab\AutoScout24\Vehicle Returns the Vehicle Object.
+     * @return Vehicle Returns the Vehicle Object.
      */
-    public function current()
-    {
+    public function current(): Vehicle
+	{
         return new Vehicle(current($this->_data));
     }
     
@@ -44,13 +44,13 @@ class VehicleQueryIterator implements \Iterator, Countable
         return key($this->_data);
     }
     
-    public function next()
+    public function next(): void
     {
-        return next($this->_data);
+        next($this->_data);
     }
     
-    public function valid()
-    {
+    public function valid(): bool
+	{
         return key($this->_data) !== null;
     }
 }


### PR DESCRIPTION
When running the library with a more recent PHP version like 8.1 a lot of warnings are generated. I made the functions compatible to the Iterator interface. 

Also added some fallbacks in the Meta class for keys that are not always available like `Options`. Tested with 7.4 and typings should all be compatible.

