### PR TITLE
Make setClient return "static" not "self"

### DIFF
--- a/src/Base/Query.php
+++ b/src/Base/Query.php
@@ -12,9 +12,9 @@ abstract class Query
      * Sets the client instance for the object.
      *
      * @param Client $client The client instance to set.
-     * @return self The current instance for method chaining.
+     * @return static The current instance for method chaining.
      */
-    public function setClient(Client $client): self
+    public function setClient(Client $client): static
     {
         $this->_client = $client;
 


### PR DESCRIPTION
The `setClient` function can also be called on children of `Query`. Meaning it is not returning `self` but `static`.

Example:
`$found = (new VehicleQuery())->setClient(Helper::get_client())->setLng($language['language_code'])->findOne($vehicle->getId());`

Without `static` as return type, type checking would assume an instance of `Query` is returned from `setClient`. Problem is only `VehicleQuery` has the `setLng` or `findOne` function.
