### PR TITLE
Add Battery Capacity and Battery Range Fields

### DIFF
--- a/src/Vehicle.php
+++ b/src/Vehicle.php
@@ -641,4 +641,20 @@ class Vehicle
     {
         return $this->_data['LeasingCalculatorUrl'];
     }
+
+	/**
+	 * @return integer i.e. 0.00
+	 */
+	public function getBatteryRentPrice()
+	{
+		return $this->_data['BatteryRentPrice'];
+	}
+
+	/**
+	 * @return integer i.e. 100
+	 */
+	public function getBatteryRange()
+	{
+		return $this->_data['BatteryRange'];
+	}
 }

--- a/src/Vehicle.php
+++ b/src/Vehicle.php
@@ -643,18 +643,18 @@ class Vehicle
     }
 
 	/**
-	 * @return integer i.e. 0.00
+	 * Gets the battery capacity.
 	 */
-	public function getBatteryRentPrice()
+	public function getBatteryCapacity()
 	{
-		return $this->_data['BatteryRentPrice'];
+		return isset($this->_data['BatteryCapacity']) ? $this->_data['BatteryCapacity'] : '' ;
 	}
 
 	/**
-	 * @return integer i.e. 100
+	 * Gets the battery range.
 	 */
 	public function getBatteryRange()
 	{
-		return $this->_data['BatteryRange'];
+		return isset($this->_data['BatteryRange']) ? $this->_data['BatteryRange'] : '';
 	}
 }


### PR DESCRIPTION
This PR introduces two new getter methods to retrieve battery-related data:

`getBatteryCapacity()`: Returns the battery capacity if available.
`getBatteryRange()`: Returns the battery range if available.
These methods ensure safe access to battery-related fields in the _data array, returning an empty string when the values are not set