### PR TITLE
Php 8.1 warning fixes

### DIFF
--- a/src/MetaQueryIterator.php
+++ b/src/MetaQueryIterator.php
@@ -68,6 +68,7 @@ class MetaQueryIterator implements \Iterator
         $this->_data = $data;
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind(): void
     {
         reset($this->_data);
@@ -76,21 +77,28 @@ class MetaQueryIterator implements \Iterator
     /**
      * @return Meta Returns the Vehicle Object.
      */
+    #[\ReturnTypeWillChange]
     public function current(): Meta
     {
         return new Meta(current($this->_data));
     }
 
+    /**
+     * @return mixed The current position key
+     */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->_data);
     }
 
+    #[\ReturnTypeWillChange]
     public function next(): void
     {
         next($this->_data);
     }
 
+    #[\ReturnTypeWillChange]
     public function valid(): bool
     {
         return key($this->_data) !== null;

--- a/src/VehicleQueryIterator.php
+++ b/src/VehicleQueryIterator.php
@@ -3,7 +3,7 @@
 namespace Indielab\AutoScout24;
 
 use Countable;
-use ReturnTypeWillChange;
+use Indielab\AutoScout24\Vehicle;
 
 class VehicleQueryIterator implements \Iterator, Countable
 {
@@ -22,11 +22,19 @@ class VehicleQueryIterator implements \Iterator, Countable
 
     public int $currentPageResultCount;
 
+    /**
+     * @return int The count of items in the collection
+     */
+    #[\ReturnTypeWillChange]
     public function count(): int
     {
         return count($this->_data);
     }
 
+    /**
+     * Rewind the Iterator to the first element
+     */
+    #[\ReturnTypeWillChange]
     public function rewind(): void
     {
         reset($this->_data);
@@ -35,21 +43,36 @@ class VehicleQueryIterator implements \Iterator, Countable
     /**
      * @return Vehicle Returns the Vehicle Object.
      */
+    #[\ReturnTypeWillChange]
     public function current(): Vehicle
     {
         return new Vehicle(current($this->_data));
     }
 
-    #[ReturnTypeWillChange] public function key() // Todo: Signature needs to be adjusted from php 8.1 onwards
+    /**
+     * @return mixed The current position key
+     */
+    #[\ReturnTypeWillChange]
+    public function key()
     {
         return key($this->_data);
     }
 
+    /**
+     * Move forward to next element
+     */
+    #[\ReturnTypeWillChange]
     public function next(): void
     {
         next($this->_data);
     }
 
+    /**
+     * Checks if current position is valid
+     * 
+     * @return bool Whether the current position is valid
+     */
+    #[\ReturnTypeWillChange]
     public function valid(): bool
     {
         return key($this->_data) !== null;


### PR DESCRIPTION
# PHP 8.1 Compatibility Fixes

## Description
This PR addresses PHP 8.1 compatibility warnings by adding the `#[\ReturnTypeWillChange]` attribute to iterator methods. The changes ensure smooth operation with PHP 8.1's stricter type checking while maintaining backward compatibility.

## Changes Made
- Added `#[\ReturnTypeWillChange]` attribute to iterator methods in `MetaQueryIterator` and `VehicleQueryIterator` classes
- Enhanced method documentation with detailed PHPDoc comments
- Improved code readability

## Testing
- Verified that the code runs without warnings on PHP 8.1
- Existing functionality remains unchanged
- All tests pass

## Additional Notes
This is a maintenance update that addresses deprecation notices introduced in PHP 8.1 for iterator implementations.